### PR TITLE
Set configuration for a Zk cluster and broker cluster using groups

### DIFF
--- a/playbooks/amq_streams_distributed.yml
+++ b/playbooks/amq_streams_distributed.yml
@@ -1,9 +1,8 @@
 ---
 - name: "Ansible Playbook to install a Zookeeper ensemble"
-  hosts: zookeeper
+  hosts: all
   vars:
     amq_streams_common_download_dir: "/tmp"
-    topic_name: myTopic
   roles:
     - role: amq_streams_zookeeper
   tasks:
@@ -18,10 +17,9 @@
         - amq_streams_zookeeper_instance_count_enabled is defined and amq_streams_zookeeper_instance_count_enabled
 
 - name: "Ansible Playbook to install a Kafka cluster"
-  hosts: brokers
+  hosts: all
   vars:
     amq_streams_common_download_dir: "/tmp"
-    amq_streams_broker_zookeeper_wait: False
     topic_name: myTopic
   roles:
     - role: amq_streams_broker

--- a/roles/amq_streams_broker/README.md
+++ b/roles/amq_streams_broker/README.md
@@ -2,6 +2,29 @@
 
 Perform installation and configuration of Kafka brokers cluster.
 
+This role requires to have a `zookeepers` group in the inventory file to identify
+each node of he Zookeeper cluster. This group is used to set up the right
+configuration files in order to establish the communication between Zookeeper cluster members.
+
+The `brokers` group is used in the same way identifying the members of the Kafka cluster.
+The order of this group will be used to set up the right configuration files and establish
+the right cluster configuration:
+
+Example of inventory:
+
+```text
+[zookeepers]
+zknode1
+zknode2
+zknode3
+
+[brokers]
+broker1
+broker2
+broker3
+broker4
+```
+
 ## Role Defaults
 
 | Variable | Description | Default |

--- a/roles/amq_streams_broker/tasks/main.yml
+++ b/roles/amq_streams_broker/tasks/main.yml
@@ -22,6 +22,7 @@
     host: "{{ amq_streams_broker_zookeeper_host }}"
     port: "{{ amq_streams_broker_zookeeper_port }}"
   when:
+    - 0 > 1 # Disabled until find a way to test the Zookeeper cluster connection (including all the zknodes)
     - amq_streams_broker_zookeeper_host is defined
     - amq_streams_broker_zookeeper_port is defined
     - amq_streams_broker_zookeeper_wait is defined and amq_streams_broker_zookeeper_wait

--- a/roles/amq_streams_broker/tasks/prereqs.yml
+++ b/roles/amq_streams_broker/tasks/prereqs.yml
@@ -14,7 +14,7 @@
     - amq_streams_broker_user is defined
     - amq_streams_broker_group is defined
 
-- name: "Ensure AMQ Streams artefacts are available."
+- name: "Ensure AMQ Streams artifacts are available."
   ansible.builtin.include_role:
     name: amq_streams_common
     tasks_from: install.yml

--- a/roles/amq_streams_broker/tasks/topic/create.yml
+++ b/roles/amq_streams_broker/tasks/topic/create.yml
@@ -1,7 +1,6 @@
 ---
-- name: "Create topic using the boostrap server."
+- name: "Create topic using the bootstrap server."
   block:
-
     - name: "Use bootstrap server to create topic {{ topic_name }}"
       ansible.builtin.include_tasks: topic/bootstrap.yml
       vars:

--- a/roles/amq_streams_broker/tasks/topic/describe.yml
+++ b/roles/amq_streams_broker/tasks/topic/describe.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Get description of topic using the boostrap server."
+- name: "Get description of topic using the bootstrap server."
   ansible.builtin.include_tasks: topic/bootstrap.yml
   vars:
     bootstrap_operator: "--describe"

--- a/roles/amq_streams_broker/templates/server.properties.j2
+++ b/roles/amq_streams_broker/templates/server.properties.j2
@@ -1,3 +1,5 @@
+# {{ ansible_managed }}
+
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -21,7 +23,8 @@
 ############################# Server Basics #############################
 
 # The id of the broker. This must be set to a unique integer for each broker.
-broker.id={{ server_id }}
+#broker.id={{ server_id }}
+broker.id={{ groups['brokers'].index(inventory_hostname) }}
 
 ############################# Socket Server Settings #############################
 
@@ -58,7 +61,6 @@ socket.receive.buffer.bytes={{ amq_streams_broker_buffer_bytes }}
 
 # The maximum size of a request that the socket server will accept (protection against OOM)
 socket.request.max.bytes={{ amq_streams_broker_socket_request_max_bytes }}
-
 
 ############################# Log Basics #############################
 
@@ -126,11 +128,10 @@ log.retention.check.interval.ms={{ amq_streams_broker_log_retention_check_interv
 # server. e.g. "127.0.0.1:3000,127.0.0.1:3001,127.0.0.1:3002".
 # You can also append an optional chroot string to the urls to specify the
 # root directory for all kafka znodes.
-zookeeper.connect={{ amq_streams_broker_zookeeper_host }}:{{ amq_streams_broker_zookeeper_port }}
+zookeeper.connect={{ amq_streams_broker_zookeeper_host }}:{{ amq_streams_broker_zookeeper_port }}{% for zknode in groups['zookeepers'] %},{{ zknode }}:{{ amq_streams_broker_zookeeper_port }}{% endfor %}
 
 # Timeout in ms for connecting to zookeeper
 zookeeper.connection.timeout.ms={{ amq_streams_broker_zookeeper_connection_timeout_ms }}
-
 
 ############################# Group Coordinator Settings #############################
 

--- a/roles/amq_streams_common/tasks/install.yml
+++ b/roles/amq_streams_common/tasks/install.yml
@@ -19,7 +19,7 @@
     - amq_streams_common_offline_install
     - amq_streams_common_redhat_enable is not defined or not amq_streams_common_redhat_enable
 
-- name: "Download artefacts (if required)."
+- name: "Download artifacts (if required)."
   ansible.builtin.include_tasks: download.yml
   when:
     - not amq_streams_common_offline_install is defined or not amq_streams_common_offline_install
@@ -29,7 +29,7 @@
     path: "{{ amq_streams_common_home }}/bin"
   register: download_target
 
-- name: "Extract artefacts to {{ amq_streams_common_install_dir }}"
+- name: "Extract artefact to {{ amq_streams_common_install_dir }}"
   ansible.builtin.unarchive:
     src: "{{ amq_streams_common_download_dir }}/{{ amq_streams_common_archive_file }}"
     dest: "{{ amq_streams_common.archive.install_dir }}"

--- a/roles/amq_streams_zookeeper/README.md
+++ b/roles/amq_streams_zookeeper/README.md
@@ -2,6 +2,19 @@
 
 Perform installation and configuration of Zookeeper ensemble.
 
+This role requires to have a `zookeepers` group in the inventory file to identify
+each node of he Zookeeper cluster. This group is used to set up the right
+configuration files in order to establish the communication between Zookeeper cluster members.
+
+Example of inventory:
+
+```text
+[zookeepers]
+zknode1
+zknode2
+zknode3
+```
+
 ## Role Defaults
 
 | Variable | Description | Default |
@@ -16,7 +29,7 @@ Perform installation and configuration of Zookeeper ensemble.
 |`amq_streams_zookeeper_service_config_template` | Zookeeper template service file | `templates/service.conf.j2` |
 |`amq_streams_zookeeper_service_env_file` | Zookeeper service environment configuration file | `/etc/zookeeper.conf` |
 |`amq_streams_zookeeper_data_dir` | Zookeeper data folder | `/var/run/zookeeper` |
-|`amq_streams_zookeeper_logs_dir` | Zookeeper logs foler | `/var/log/{{ amq_streams_zookeeper_service_name }}/` |
+|`amq_streams_zookeeper_logs_dir` | Zookeeper logs foler | `/var/logs/{{ amq_streams_zookeeper_service_name }}/` |
 |`amq_streams_zookeeper_max_client_cnxns` | Max client connections | `0` |
 |`amq_streams_zookeeper_admin_enable_server` | Enable zookeeper administration server | `false` |
 |`amq_streams_zookeeper_instance_count_enabled` | Count zookeeper instances | `true` |
@@ -25,6 +38,10 @@ Perform installation and configuration of Zookeeper ensemble.
 |`amq_streams_zookeeper_port` |  | `2181` |
 |`amq_streams_firewalld_package_name` |  | `- firewalld` |
 |`amq_streams_firewalld_enabled` |  | `false` |
+|`amq_streams_zookeeper_init_limit` |  | `5` |
+|`amq_streams_zookeeper_sync_limit` |  | `2` |
+|`amq_streams_zookeeper_cluster_port_start` |  | `2888` |
+|`amq_streams_zookeeper_cluster_port_end` |  | `3888` |
 
 ## Role Variables
 

--- a/roles/amq_streams_zookeeper/defaults/main.yml
+++ b/roles/amq_streams_zookeeper/defaults/main.yml
@@ -9,14 +9,20 @@ amq_streams_zookeeper_service_name: 'amq_streams_zookeeper'
 amq_streams_zookeeper_service_config_template: 'templates/service.conf.j2'
 amq_streams_zookeeper_service_env_file: '/etc/zookeeper.conf'
 amq_streams_zookeeper_data_dir: /var/run/zookeeper
-amq_streams_zookeeper_logs_dir: "/var/log/{{ amq_streams_zookeeper_service_name }}/"
+amq_streams_zookeeper_logs_dir: "/var/logs/{{ amq_streams_zookeeper_service_name }}/"
 amq_streams_zookeeper_max_client_cnxns: 0
-amq_streams_zookeeper_admin_enable_server: 'false'
+amq_streams_zookeeper_admin_enable_server: 'true'
+amq_streams_zookeeper_admin_server_port: 8080
 amq_streams_zookeeper_instance_count_enabled: true
+amq_streams_zookeeper_4wl_commands_whitelist: stat,dump # "*"
 amq_streams_zookeeper_instance_count: 0
 
 amq_streams_zookeeper_host: localhost
 amq_streams_zookeeper_port: 2181
+amq_streams_zookeeper_init_limit: 5
+amq_streams_zookeeper_sync_limit: 2
+amq_streams_zookeeper_cluster_port_start: 2888
+amq_streams_zookeeper_cluster_port_end: 3888
 
 amq_streams_firewalld_package_name:
   - firewalld

--- a/roles/amq_streams_zookeeper/tasks/main.yml
+++ b/roles/amq_streams_zookeeper/tasks/main.yml
@@ -12,6 +12,13 @@
   when:
     - amq_streams_zookeeper_data_dir is defined
 
+- name: Configure 'myid' file based on the position in the zookeepers group
+  copy: 
+    content: "{{ groups['zookeepers'].index(inventory_hostname) + 1 }}"
+    dest: "{{ amq_streams_zookeeper_data_dir }}/myid"
+    owner: "{{ amq_streams_zookeeper_user | default(omit) }}"
+    group: "{{ amq_streams_zookeeper_group | default(omit) }}"
+
 - name: "Configure firewalld for Zookeeper (if enable)."
   ansible.builtin.include_role:
     name: amq_streams_common

--- a/roles/amq_streams_zookeeper/templates/zookeeper.properties.j2
+++ b/roles/amq_streams_zookeeper/templates/zookeeper.properties.j2
@@ -1,3 +1,5 @@
+# {{ ansible_managed }}
+
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -12,13 +14,35 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 # the directory where the snapshot is stored.
 dataDir={{ amq_streams_zookeeper_data_dir }}
+
 # the port at which the clients will connect
 clientPort={{ amq_streams_zookeeper_port }}
+
 # disable the per-ip limit on the number of connections since this is a non-production config
 maxClientCnxns={{ amq_streams_zookeeper_max_client_cnxns }}
+
+# Enable command list - https://zookeeper.apache.org/doc/r3.5.5/zookeeperAdmin.html
+4lw.commands.whitelist={{ amq_streams_zookeeper_4wl_commands_whitelist }}
+
 # Disable the adminserver by default to avoid port conflicts.
 # Set the port to something non-conflicting if choosing to enable this
 admin.enableServer={{ amq_streams_zookeeper_admin_enable_server }}
-# admin.serverPort=8080
+{% if amq_streams_zookeeper_admin_enable_server %}
+admin.serverPort={{ amq_streams_zookeeper_admin_server_port }}
+{% endif %}
+
+# Amount of time to allow followers to connect and sync to the cluster leader. 
+# The time is specified as a number of ticks
+initLimit={{ amq_streams_zookeeper_init_limit }}
+
+# Amount of time for which followers can be behind the leader.
+# The time is specified as a number of ticks
+syncLimit={{ amq_streams_zookeeper_sync_limit }}
+
+# List of servers which should be members of the Zookeeper cluster.
+{% for zknode in groups['zookeepers'] %}
+server.{{ loop.index }}={{ zknode }}:{{ amq_streams_zookeeper_cluster_port_start }}:{{ amq_streams_zookeeper_cluster_port_end }}:participant;{{ zknode }}:{{ amq_streams_zookeeper_port }}
+{% endfor %}


### PR DESCRIPTION
This PR is a proposal to fix the #7 including the extension of create the zookeeper (ZK) and broker (BK) cluster successfuly. The current status of the `main` branch does not include the right configuration in the `zookeeper.properties` and `server.properties` file to set up each cluster. These files must include a set of properties to identify each member of the ZK and BK cluster to establish the connectivy between members and then have a complete topology working as expected.

For example, the current status of the `main` branch defines some properties as standalone, so it is great, when you want to have a one-to-one topology (one ZK instance and a single BK instance):

* `broker.id=0` in the `server.properties` file
* Missing the `zookeeper.connect` property in the `server.properties` file
* Missing the `server.X` properties in the `zookeeper.properties` (and other properties to create the cluster)

Checking the ZK Admin Server, the instance is defined as standalone:

```shell
[rhmw@f38mw01 ~]$ curl http://localhost:8080/commands/stat
{
  "version" : "3.6.3--6401e4ad2087061bc6b9f80dec2d69f2e3c8660a, built on 04/08/2021 16:35 GMT",
  "read_only" : false,
  "server_stats" : {
    "packets_sent" : 0,
    "packets_received" : 0,
    "fsync_threshold_exceed_count" : 0,
    "client_response_stats" : {
      "last_buffer_size" : -1,
      "min_buffer_size" : -1,
      "max_buffer_size" : -1
    },
    "uptime" : 76287,
    "data_dir_size" : 457,
    "log_dir_size" : 457,
    "provider_null" : false,
    "last_processed_zxid" : 0,
    "outstanding_requests" : 0,
    "server_state" : "standalone",
    "avg_latency" : 0.0,
    "max_latency" : 0,
    "min_latency" : 0,
    "num_alive_client_connections" : 0,
    "auth_failed_count" : 0,
    "non_mtlsremote_conn_count" : 0,
    "non_mtlslocal_conn_count" : 0
  },
  "client_response" : {
    "last_buffer_size" : -1,
    "min_buffer_size" : -1,
    "max_buffer_size" : -1
  },
  "node_count" : 5,
  "connections" : [ ],
  "secure_connections" : [ ],
  "command" : "stats",
  "error" : null
}
```` 

Another way to check that it is not a distributed cluster is creating a topic with more replicas. Then the following exception will raise:

```text
Error while executing topic command : Replication factor: 3 larger than available brokers: 1.
[2023-06-08 23:03:21,771] ERROR org.apache.kafka.common.errors.InvalidReplicationFactorException: Replication factor: 3 larger than available brokers: 1.
 (kafka.admin.TopicCommand$)
```

This PR includes a set of configurations and templates for these files allowing to define the different members of the ZK and BK clusters. Using the `zookeeper` and `brokers` groups in the inventory the roles will use them to set up everything in the right way.

After seeting that, it is easy to check the status of a ZK instance using the Admin Server endpoint, and identify the status of each member, as `leader` or `follower`. Here an example of a leader node:

```shell
[rhmw@f38mw01 zookeeper]$ curl http://localhost:8080/commands/stat
{
  "version" : "3.6.3--6401e4ad2087061bc6b9f80dec2d69f2e3c8660a, built on 04/08/2021 16:35 GMT",
  "read_only" : false,
  "server_stats" : {
    "packets_sent" : 0,
    "packets_received" : 0,
    "fsync_threshold_exceed_count" : 0,
    "client_response_stats" : {
      "last_buffer_size" : -1,
      "min_buffer_size" : -1,
      "max_buffer_size" : -1
    },
    "provider_null" : false,
    "server_state" : "leader",
    "outstanding_requests" : 0,
    "min_latency" : 0,
    "avg_latency" : 0.0,
    "max_latency" : 0,
    "data_dir_size" : 67114438,
    "log_dir_size" : 67114438,
    "last_processed_zxid" : 12884901888,
    "num_alive_client_connections" : 0,
    "auth_failed_count" : 0,
    "non_mtlsremote_conn_count" : 0,
    "non_mtlslocal_conn_count" : 0,
    "uptime" : 3456
  },
  "client_response" : {
    "last_buffer_size" : -1,
    "min_buffer_size" : -1,
    "max_buffer_size" : -1
  },
  "proposal_stats" : {
    "last_buffer_size" : -1,
    "min_buffer_size" : -1,
    "max_buffer_size" : -1
  },
  "node_count" : 26,
  "connections" : [ ],
  "secure_connections" : [ ],
  "command" : "stats",
  "error" : null
}
``` 

## Bonus track

This PR also includes a set of properties to enable the ZK Admin Server (including the port). Very useful to check the status of the ZK nodes.
