### PR TITLE
🐛 Add zk inventory group var into broker role

### DIFF
--- a/roles/amq_streams_broker/defaults/main.yml
+++ b/roles/amq_streams_broker/defaults/main.yml
@@ -74,3 +74,4 @@ amq_streams_broker_auth_sasl_mechanisms:
 amq_streams_broker_server_log_validation_min_size: 20
 
 amq_streams_broker_inventory_group: "{{ groups['brokers'] | default('') }}"
+amq_streams_zookeeper_inventory_group: "{{ groups['zookeepers'] | default('') }}"


### PR DESCRIPTION
This PR fixes an issue coming from the #44. The `amq_streams_zookeeper_inventory_group` variable must be part also the `amq_streams_broker` role just because the `server.properties.j2` template uses it to set up the connection to the zookeeper cluster.

The issue was:

```text
TASK [amq_streams_common : Ensure amq_streams_broker configuration is deployed.] **********************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ansible.errors.AnsibleUndefinedVariable: 'amq_streams_zookeeper_inventory_group' is undefined
fatal: [f38mw01]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: 'amq_streams_zookeeper_inventory_group' is undefined"}
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ansible.errors.AnsibleUndefinedVariable: 'amq_streams_zookeeper_inventory_group' is undefined
```

@rpelisse Can you review it? Maybe there is another way to declare these variables to identify the group vars.
