### PR TITLE
⬆️ Upgrade to Kafka 3.4.0

### DIFF
--- a/roles/amq_streams_common/README.md
+++ b/roles/amq_streams_common/README.md
@@ -6,7 +6,7 @@ Common tasks for the collection.
 
 | Variable | Description | Default |
 |:---------|:------------|:--------|
-|`amq_streams_common_product_version` | Kafka version | `3.3.2` |
+|`amq_streams_common_product_version` | Kafka version | `3.4.0` |
 |`amq_streams_common_scala_version` | Scala version | `2.13` |
 |`amq_streams_common_version` | Combination version | `{{ amq_streams_common_scala_version }}-{{ amq_streams_common_product_version }}` |
 |`amq_streams_common_archive_file` | Kafka binary package | `kafka_{{ amq_streams_common_version }}.tgz` |

--- a/roles/amq_streams_common/defaults/main.yml
+++ b/roles/amq_streams_common/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-amq_streams_common_product_version: 3.3.2
+amq_streams_common_product_version: 3.4.0
 amq_streams_common_scala_version: 2.13
 amq_streams_common_version: "{{ amq_streams_common_scala_version }}-{{ amq_streams_common_product_version }}"
 amq_streams_common_archive_file: "kafka_{{ amq_streams_common_version }}.tgz"

--- a/roles/amq_streams_common/meta/argument_specs.yml
+++ b/roles/amq_streams_common/meta/argument_specs.yml
@@ -2,7 +2,7 @@ argument_specs:
     main:
         options:
             amq_streams_common_product_version:
-                default: 3.3.2
+                default: 3.4.0
                 description: "Version of Apache Kafka to download and install"
                 type: "str"
             amq_streams_common_scala_version:


### PR DESCRIPTION
The latest version of AMQ Streams 2.4.0 is based in Kafka 3.4.0. This PR includes the upgrade of the collection to use the upstream version of Kafka used by AMQ Streams 2.4.0.

Reference: https://access.redhat.com/articles/6649131
