### PR TITLE
Manage topics in a Kafka authenticated broker

### DIFF
--- a/playbooks/amq_streams_all_auth.yml
+++ b/playbooks/amq_streams_all_auth.yml
@@ -1,0 +1,118 @@
+---
+- name: "Ansible Playbook to install Zookeeper and Broker with Authentication"
+  hosts: all
+  vars:
+    # Enabling Zookeeper Authentication
+    amq_streams_zookeeper_auth_enabled: true
+    amq_streams_zookeeper_auth_user: zkadmin
+    amq_streams_zookeeper_auth_pass: p@ssw0rd
+
+    # Enabling Kafka Broker Listeners
+    amq_streams_broker_listeners:
+      - AUTHENTICATED://:{{ amq_streams_broker_listener_port }}
+      - REPLICATION://:{{ amq_streams_broker_listener_internal_port }}
+
+    # Listener for inter-broker communications
+    amq_streams_broker_inter_broker_listener: REPLICATION
+
+    # Enabling Kafka Broker Authentication
+    amq_streams_broker_auth_enabled: true
+    amq_streams_broker_auth_scram_enabled: true
+    amq_streams_broker_auth_listeners:
+      - AUTHENTICATED:SASL_PLAINTEXT
+      - REPLICATION:PLAINTEXT
+
+    amq_streams_broker_auth_sasl_mechanisms:
+      - PLAIN
+      - SCRAM-SHA-512
+
+    # Kafka Plain Users
+    amq_streams_broker_auth_plain_users:
+      - username: admin
+        password: p@ssw0rd
+      - username: kafkauser
+        password: p@ssw0rd
+
+    # Defining default Kafka user for administrative tasks
+    amq_streams_broker_admin_mechanism: PLAIN
+    #amq_streams_broker_admin_mechanism: SCRAM-SHA-512
+    amq_streams_broker_admin_username: admin
+    amq_streams_broker_admin_password: p@ssw0rd
+
+    # Topic Management
+    amq_streams_broker_topics:
+      - name: sampleTopic
+        partitions: 1
+        replication_factor: 1
+      - name: otherTopic
+        partitions: 1
+        replication_factor: 1
+  roles:
+    - role: amq_streams_zookeeper
+  tasks:
+    - name: "Ensure Zookeeper is running and available."
+      ansible.builtin.include_role:
+        name: amq_streams_zookeeper
+      vars:
+        amq_streams_common_skip_download: true
+
+    - name: "Ensure Broker is running and available."
+      ansible.builtin.include_role:
+        name: amq_streams_broker
+      vars:
+        amq_streams_common_skip_download: true
+
+    - name: "Create topics"
+      ansible.builtin.include_role:
+        name: amq_streams_broker
+        tasks_from: topic/create.yml
+      loop: "{{ amq_streams_broker_topics }}"
+      loop_control:
+        loop_var: topic
+      vars:
+        topic_name: "{{ topic.name }}"
+        topic_partitions: "{{ topic.partitions }}"
+        topic_replication_factor: "{{ topic.replication_factor }}"
+
+    - name: "Describe topics"
+      ansible.builtin.include_role:
+        name: amq_streams_broker
+        tasks_from: topic/describe.yml
+      loop: "{{ amq_streams_broker_topics }}"
+      loop_control:
+        loop_var: topic
+      vars:
+        topic_name: "{{ topic.name }}"
+
+    - name: "Delete topics"
+      ansible.builtin.include_role:
+        name: amq_streams_broker
+        tasks_from: topic/delete.yml
+      loop: "{{ amq_streams_broker_topics }}"
+      loop_control:
+        loop_var: topic
+      vars:
+        topic_name: "{{ topic.name }}"
+
+  post_tasks:
+    - name: "Display numbers of Zookeeper instances managed by Ansible."
+      ansible.builtin.debug:
+        msg: "Numbers of Zookeeper instances: {{ amq_streams_zookeeper_instance_count }}."
+      when:
+        - amq_streams_zookeeper_instance_count_enabled is defined and amq_streams_zookeeper_instance_count_enabled
+
+    - name: "Display numbers of broker instances managed by Ansible:"
+      ansible.builtin.debug:
+        msg: "Numbers of broker instances: {{ amq_streams_broker_instance_count }}."
+      when:
+        - amq_streams_broker_instance_count_enabled is defined and amq_streams_broker_instance_count_enabled
+
+    - name: "Validate that Zookeeper deployment is functional."
+      ansible.builtin.include_role:
+        name: amq_streams_zookeeper
+        tasks_from: validate.yml
+
+    - name: "Validate that Broker deployment is functional."
+      ansible.builtin.include_role:
+        name: amq_streams_broker
+        tasks_from: validate.yml

--- a/roles/amq_streams_broker/README.md
+++ b/roles/amq_streams_broker/README.md
@@ -89,7 +89,7 @@ The following are a set of required variables for the role:
 | Variable | Description | Required |
 |:---------|:------------|:---------|
 |`amq_streams_zookeeper_auth_user` | Zookeeper user to authenticate. Mandatory if `amq_streams_zookeeper_auth_enabled: true` | 'true' |
-|`amq_streams_zookeeper_auth_pass` | Zookeeper user password to authenticate. Mandatory if `amq_streams_zookeeper_auth_enabled: true`| 'true' |
+|`amq_streams_zookeeper_auth_pass` | Zookeeper user password to authenticate. Mandatory if `amq_streams_zookeeper_auth_enabled: true`| `true` |
 
 Enabling the `amq_streams_broker_auth_enabled` requires to define the following variables to execute the role successfully:
 
@@ -108,7 +108,7 @@ Enabling the `amq_streams_broker_auth_enabled` requires to define the following 
 This section includes a set of example to enable the broker authentication for the
 following scenarios:
 
-* SASL Plain authentication
+* SASL PLAIN authentication
 * SASL SCRAM authentication 
 
 ### SASL Plain Authentication

--- a/roles/amq_streams_broker/defaults/main.yml
+++ b/roles/amq_streams_broker/defaults/main.yml
@@ -48,7 +48,7 @@ amq_streams_broker_zookeeper_port_default_value: 2181
 amq_streams_broker_zookeeper_wait: True
 
 # Broker-Zookeeper Authentication with SASL
-amq_streams_zookeeper_auth_enabled: 'false'
+amq_streams_zookeeper_auth_enabled: false
 amq_streams_broker_zookeeper_auth_config: /etc/broker-jaas.conf
 amq_streams_broker_zookeeper_auth_config_template: templates/broker-jaas.conf.j2
 
@@ -59,8 +59,8 @@ amq_streams_broker_listeners:
   #- AUTHENTICATED://:9093 # Authenticated
 
 # Broker Authentication
-amq_streams_broker_auth_enabled: 'false'
-amq_streams_broker_auth_scram_enabled: 'false'
+amq_streams_broker_auth_enabled: false
+amq_streams_broker_auth_scram_enabled: false
 amq_streams_connect_broker_auth_username: broker
 amq_streams_connect_broker_auth_password: PLEASE_CHANGEME_IAMNOTGOOD_FOR_PRODUCTION
 
@@ -80,5 +80,6 @@ amq_streams_zookeeper_inventory_group: "{{ groups['zookeepers'] | default('') }}
 
 amq_streams_broker_admin_cli_config_template: 'templates/admin-cli.properties.j2'
 amq_streams_broker_admin_cli_config_file: '/tmp/admin-cli.properties'
+amq_streams_broker_admin_mechanism: PLAIN
 amq_streams_broker_admin_username: PLEASE_IDENTIFY_THE_ADMIN_USER
 amq_streams_broker_admin_password: PLEASE_CHANGEME_IAMNOTGOOD_FOR_PRODUCTION

--- a/roles/amq_streams_broker/defaults/main.yml
+++ b/roles/amq_streams_broker/defaults/main.yml
@@ -77,3 +77,8 @@ amq_streams_broker_server_log_validation_min_size: 20
 
 amq_streams_broker_inventory_group: "{{ groups['brokers'] | default('') }}"
 amq_streams_zookeeper_inventory_group: "{{ groups['zookeepers'] | default('') }}"
+
+amq_streams_broker_admin_cli_config_template: 'templates/admin-cli.properties.j2'
+amq_streams_broker_admin_cli_config_file: '/tmp/admin-cli.properties'
+amq_streams_broker_admin_username: PLEASE_IDENTIFY_THE_ADMIN_USER
+amq_streams_broker_admin_password: PLEASE_CHANGEME_IAMNOTGOOD_FOR_PRODUCTION

--- a/roles/amq_streams_broker/tasks/topic/bootstrap.yml
+++ b/roles/amq_streams_broker/tasks/topic/bootstrap.yml
@@ -25,17 +25,17 @@
     src: "{{ amq_streams_broker_admin_cli_config_template }}"
     dest: "{{ amq_streams_broker_admin_cli_config_file }}"
   when:
-    - amq_streams_broker_auth_enabled is defined
+    - amq_streams_broker_auth_enabled is defined and amq_streams_broker_auth_enabled
 
 - name: "Set command-config argument to run operation '{{ bootstrap_operator }}' for topic: '{{ topic_name }}'."
   ansible.builtin.set_fact:
     bootstrap_command_config_operator_option: "--command-config {{ amq_streams_broker_admin_cli_config_file }}"
   when:
-    - amq_streams_broker_auth_enabled is defined
+    - amq_streams_broker_auth_enabled is defined and amq_streams_broker_auth_enabled
 
 - name: "Run operation '{{ bootstrap_operator }}' for topic: '{{ topic_name }}'."
   block:
     - name: "Execute create request for topic '{{ topic_name }}'."
-      ansible.builtin.command: "{{ amq_streams_broker.topic.script }} {{ bootstrap_operator }} {{ bootstrap_operator_options | default('') }} {{ bootstrap_command_config_operator_option }} --topic {{ topic_name }} --bootstrap-server {{ bootstrap_server_host }}:{{ bootstrap_server_port }}"
+      ansible.builtin.command: "{{ amq_streams_broker.topic.script }} {{ bootstrap_operator }} {{ bootstrap_operator_options | default('') }} {{ bootstrap_command_config_operator_option | default('')}} --topic {{ topic_name }} --bootstrap-server {{ bootstrap_server_host }}:{{ bootstrap_server_port }}"
       register: operation_result
       changed_when: False

--- a/roles/amq_streams_broker/tasks/topic/bootstrap.yml
+++ b/roles/amq_streams_broker/tasks/topic/bootstrap.yml
@@ -20,9 +20,22 @@
   when:
     - not bootstrap_server_port is defined
 
+- name: "Generate Admin CLI properties file"
+  ansible.builtin.template:
+    src: "{{ amq_streams_broker_admin_cli_config_template }}"
+    dest: "{{ amq_streams_broker_admin_cli_config_file }}"
+  when:
+    - amq_streams_broker_auth_enabled is defined
+
+- name: "Set command-config argument to run operation '{{ bootstrap_operator }}' for topic: '{{ topic_name }}'."
+  ansible.builtin.set_fact:
+    bootstrap_command_config_operator_option: "--command-config {{ amq_streams_broker_admin_cli_config_file }}"
+  when:
+    - amq_streams_broker_auth_enabled is defined
+
 - name: "Run operation '{{ bootstrap_operator }}' for topic: '{{ topic_name }}'."
   block:
     - name: "Execute create request for topic '{{ topic_name }}'."
-      ansible.builtin.command: "{{ amq_streams_broker.topic.script }} {{ bootstrap_operator }} {{ bootstrap_operator_options | default('') }} --topic {{ topic_name }} --bootstrap-server {{ bootstrap_server_host }}:{{ bootstrap_server_port }}"
+      ansible.builtin.command: "{{ amq_streams_broker.topic.script }} {{ bootstrap_operator }} {{ bootstrap_operator_options | default('') }} {{ bootstrap_command_config_operator_option }} --topic {{ topic_name }} --bootstrap-server {{ bootstrap_server_host }}:{{ bootstrap_server_port }}"
       register: operation_result
       changed_when: False

--- a/roles/amq_streams_broker/tasks/topic/create.yml
+++ b/roles/amq_streams_broker/tasks/topic/create.yml
@@ -11,7 +11,7 @@
       ansible.builtin.set_fact:
         bootstrap_create_operator_replication_factor_option: "--replication-factor {{ topic_replication_factor }}"
       when:
-        - topic_replication_factor is defined        
+        - topic_replication_factor is defined
 
     - name: "Use bootstrap server to create topic {{ topic_name }}"
       ansible.builtin.include_tasks: topic/bootstrap.yml

--- a/roles/amq_streams_broker/templates/admin-cli.properties.j2
+++ b/roles/amq_streams_broker/templates/admin-cli.properties.j2
@@ -1,0 +1,14 @@
+// {{ ansible_managed }}
+
+{% if amq_streams_broker_auth_enabled %}
+security.protocol=SASL_PLAINTEXT
+{% if amq_streams_broker_admin_mechanism == "PLAIN" %}
+# Plain Login Module
+sasl.mechanism=PLAIN
+sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="{{ amq_streams_broker_admin_username }}" password="{{ amq_streams_broker_admin_password }}";
+{% elif amq_streams_broker_admin_mechanism == "SCRAM-SHA-512" %}
+# SCRAM Login Module
+sasl.mechanism=SCRAM-SHA-512
+sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="{{ amq_streams_broker_admin_username }}" password="{{ amq_streams_broker_admin_password }}";
+{% endif %}
+{% endif %}

--- a/roles/amq_streams_broker/templates/server.properties.j2
+++ b/roles/amq_streams_broker/templates/server.properties.j2
@@ -23,7 +23,6 @@
 ############################# Server Basics #############################
 
 # The id of the broker. This must be set to a unique integer for each broker.
-#broker.id={{ server_id }}
 broker.id={{ amq_streams_broker_inventory_group.index(inventory_hostname) }}
 
 ############################# Socket Server Settings #############################

--- a/roles/amq_streams_common/tasks/install.yml
+++ b/roles/amq_streams_common/tasks/install.yml
@@ -29,7 +29,7 @@
     path: "{{ amq_streams_common_home }}/bin"
   register: download_target
 
-- name: "Extract artefact to {{ amq_streams_common_install_dir }}"
+- name: "Extract artifact to {{ amq_streams_common_install_dir }}"
   ansible.builtin.unarchive:
     src: "{{ amq_streams_common_download_dir }}/{{ amq_streams_common_archive_file }}"
     dest: "{{ amq_streams_common.archive.install_dir }}"

--- a/roles/amq_streams_common/tasks/prereqs.yml
+++ b/roles/amq_streams_common/tasks/prereqs.yml
@@ -21,7 +21,7 @@
     - prereqs_user is defined
     - prereqs_group is defined
 
-- name: "Ensure AMQ Streams artefacts are available."
+- name: "Ensure AMQ Streams artifacts are available."
   ansible.builtin.include_role:
     name: amq_streams_common
     tasks_from: install.yml

--- a/roles/amq_streams_zookeeper/defaults/main.yml
+++ b/roles/amq_streams_zookeeper/defaults/main.yml
@@ -33,7 +33,7 @@ amq_streams_firewalld_package_name:
 amq_streams_firewalld_enabled: false
 
 # Zookeeper Authentication with SASL
-amq_streams_zookeeper_auth_enabled: 'false'
+amq_streams_zookeeper_auth_enabled: false
 amq_streams_zookeeper_auth_config: /etc/zookeeper-jaas.conf
 amq_streams_zookeeper_auth_config_template: templates/zookeeper-jaas.conf.j2
 amq_streams_zookeeper_auth_user: zookeeper


### PR DESCRIPTION
This PR extends the kafka topics tasks of the `amq_streams_broker` role when the Kafka broker is authenticated.

The PR also extends the documentation describing how to create, describe or delete topics using the role.
