### PR TITLE
Manage SCRAM users in an authenticated broker

### DIFF
--- a/playbooks/amq_streams_all_auth.yml
+++ b/playbooks/amq_streams_all_auth.yml
@@ -30,7 +30,16 @@
     amq_streams_broker_auth_plain_users:
       - username: admin
         password: p@ssw0rd
-      - username: kafkauser
+      - username: kafkauser01
+        password: p@ssw0rd
+      - username: kafkauser02
+        password: p@ssw0rd
+
+    # Kafka SCRAM Users
+    amq_streams_broker_auth_scram_users:
+      - username: kafkascramuser01
+        password: p@ssw0rd
+      - username: kafkascramuser02
         password: p@ssw0rd
 
     # Defining default Kafka user for administrative tasks
@@ -93,6 +102,37 @@
         loop_var: topic
       vars:
         topic_name: "{{ topic.name }}"
+
+    - name: "Create SCRAM users"
+      ansible.builtin.include_role:
+        name: amq_streams_broker
+        tasks_from: user-scram/create.yml
+      loop: "{{ amq_streams_broker_auth_scram_users }}"
+      loop_control:
+        loop_var: user
+      vars:
+        user_username: "{{ user.username }}"
+        user_password: "{{ user.password }}"
+
+    - name: "Describe SCRAM users"
+      ansible.builtin.include_role:
+        name: amq_streams_broker
+        tasks_from: user-scram/describe.yml
+      loop: "{{ amq_streams_broker_auth_scram_users }}"
+      loop_control:
+        loop_var: user
+      vars:
+        user_username: "{{ user.username }}"
+
+    - name: "Delete SCRAM users"
+      ansible.builtin.include_role:
+        name: amq_streams_broker
+        tasks_from: user-scram/delete.yml
+      loop: "{{ amq_streams_broker_auth_scram_users }}"
+      loop_control:
+        loop_var: user
+      vars:
+        user_username: "{{ user.username }}"
 
   post_tasks:
     - name: "Display numbers of Zookeeper instances managed by Ansible."

--- a/roles/amq_streams_broker/README.md
+++ b/roles/amq_streams_broker/README.md
@@ -80,7 +80,7 @@ broker4
 |`amq_streams_broker_auth_listeners` | Default list of authenticated listeners | `PLAINTEXT:PLAINTEXT` |
 |`amq_streams_broker_auth_sasl_mechanisms` | Default list of authenticated SASL mechanism | `PLAIN` |
 |`amq_streams_broker_inventory_group` | Identify the group of broker nodes | `groups['brokers']` |
-|`amq_streams_broker_topics` | List of topics to create. Each topics requires the `name` property, and optionally the `partitions` and `replication_factor` | | 
+|`amq_streams_broker_topics` | List of topics to create. Each topics requires the `name` property, and optionally the `partitions` and `replication_factor` | |
 
 ## Role Variables
 
@@ -100,8 +100,8 @@ Enabling the `amq_streams_broker_auth_enabled` requires to define the following 
   - AUTHENTICATED://:9093` |
 |`amq_streams_broker_auth_sasl_mechanisms` | Default list of authenticated SASL mechanism | `true` | `PLAIN` |
 |`amq_streams_broker_auth_plain_users` | List of users (`username`, `password`) to add into the Kafka cluster | `true` | `` |
-|`amq_streams_broker_admin_username` | Default admin user to manage topics | `false` |  | 
-|`amq_streams_broker_admin_password` | Default password of the admin user to manage topics | `false` |  | 
+|`amq_streams_broker_admin_username` | Default admin user to manage topics | `false` |  |
+|`amq_streams_broker_admin_password` | Default password of the admin user to manage topics | `false` |  |
 
 ## Broker Authentication
 
@@ -109,7 +109,7 @@ This section includes a set of example to enable the broker authentication for t
 following scenarios:
 
 * SASL PLAIN authentication
-* SASL SCRAM authentication 
+* SASL SCRAM authentication
 
 ### SASL Plain Authentication
 
@@ -195,6 +195,74 @@ by the `amq_streams_broker_inter_broker_listener_auth` variable.
       listener.name.replication.scram-sha-512.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="<USER>" password="<PASSWORD>";
 ```
 
+To manage SCRAM users, the role includes the following tasks:
+
+* Create
+* Describe
+* Delete
+
+
+The role uses the `amq_streams_broker_topics` variable to identify the list of topics
+to be managed by the role for each stage of the life cycle.
+
+The `amq_streams_broker_auth_scram_users` variable defines the list of
+different SCRAM users to manage in the Kafka cluster.
+
+Example of definition of SCRAM users:
+
+```yaml
+  vars:
+    # Kafka SCRAM Users
+    amq_streams_broker_auth_scram_users:
+      - username: kafkauser01
+        password: p@ssw0rd
+      - username: kafkauser02
+        password: p@ssw0rd
+```
+
+Creating SCRAM users can be done with this task:
+
+```yaml
+    - name: "Create SCRAM users"
+      ansible.builtin.include_role:
+        name: amq_streams_broker
+        tasks_from: user-scram/create.yml
+      loop: "{{ amq_streams_broker_auth_scram_users }}"
+      loop_control:
+        loop_var: user
+      vars:
+        user_username: "{{ user.username }}"
+        user_password: "{{ user.password }}"
+```
+
+Describing SCRAM users can be done with this task:
+
+```yaml
+    - name: "Describe SCRAM users"
+      ansible.builtin.include_role:
+        name: amq_streams_broker
+        tasks_from: user-scram/describe.yml
+      loop: "{{ amq_streams_broker_auth_scram_users }}"
+      loop_control:
+        loop_var: user
+      vars:
+        user_username: "{{ user.username }}"
+```
+
+Deleting SCRAM users can be done with this task:
+
+```yaml
+    - name: "Delete SCRAM users"
+      ansible.builtin.include_role:
+        name: amq_streams_broker
+        tasks_from: user-scram/delete.yml
+      loop: "{{ amq_streams_broker_auth_scram_users }}"
+      loop_control:
+        loop_var: user
+      vars:
+        user_username: "{{ user.username }}"
+```
+
 ## Topic Management
 
 The role allows to manage the following stages of the life cycle of topics:
@@ -204,7 +272,7 @@ The role allows to manage the following stages of the life cycle of topics:
 * Delete
 
 The role uses the `amq_streams_broker_topics` variable to identify the list of topics
-to be managed by the role for each stage of the life cycle. 
+to be managed by the role for each stage of the life cycle.
 
 Example of definition of topics:
 
@@ -221,7 +289,7 @@ Example of definition of topics:
 ```
 
 **NOTE:** To manage topics in a distributed Kafka broker, the operation should be done
-in one single broker instance. Create or delete actions are replicated across the Kafka cluster. 
+in one single broker instance. Create or delete actions are replicated across the Kafka cluster.
 
 ### Create Topics
 

--- a/roles/amq_streams_broker/defaults/main.yml
+++ b/roles/amq_streams_broker/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 amq_streams_broker_create_topic_script: "{{ amq_streams_common_home }}/bin/kafka-topics.sh"
+amq_streams_broker_kafka_config_script: "{{ amq_streams_common_home }}/bin/kafka-configs.sh"
 amq_streams_broker_enabled: true
 amq_streams_broker_server_start: "{{ amq_streams_common_home }}/bin/kafka-server-start.sh"
 amq_streams_broker_config: "/etc/amq_streams_broker.properties"

--- a/roles/amq_streams_broker/tasks/user-scram/bootstrap.yml
+++ b/roles/amq_streams_broker/tasks/user-scram/bootstrap.yml
@@ -1,0 +1,41 @@
+---
+- name: "Ensure required parameter(s) are provided."
+  ansible.builtin.assert:
+    that:
+      - amq_streams_broker is defined
+      - amq_streams_broker.topic is defined
+      - amq_streams_broker.topic.script is defined
+      - user_username is defined
+    quiet: True
+
+- name: "Set bootstrap server host (if not defined)."
+  ansible.builtin.set_fact:
+    bootstrap_server_host: "{{ amq_streams_broker.bootstrap_server.host }}"
+  when:
+    - not bootstrap_server_host is defined
+
+- name: "Set bootstrap server port (if not defined)."
+  ansible.builtin.set_fact:
+    bootstrap_server_port: "{{ amq_streams_broker.bootstrap_server.port }}"
+  when:
+    - not bootstrap_server_port is defined
+
+- name: "Generate Admin CLI properties file"
+  ansible.builtin.template:
+    src: "{{ amq_streams_broker_admin_cli_config_template }}"
+    dest: "{{ amq_streams_broker_admin_cli_config_file }}"
+  when:
+    - amq_streams_broker_auth_enabled is defined and amq_streams_broker_auth_enabled
+
+- name: "Set command-config argument to run operation '{{ bootstrap_operator }}' for user: '{{ user_username }}'."
+  ansible.builtin.set_fact:
+    bootstrap_command_config_operator_option: "--command-config {{ amq_streams_broker_admin_cli_config_file }}"
+  when:
+    - amq_streams_broker_auth_enabled is defined and amq_streams_broker_auth_enabled
+
+- name: "Run operation '{{ bootstrap_operator }}' for user: '{{ user_username }}'."
+  block:
+    - name: "Execute create request for user '{{ user_username }}'."
+      ansible.builtin.command: "{{ amq_streams_broker.config.script }} {{ bootstrap_operator }} {{ bootstrap_operator_options | default('') }} {{ bootstrap_command_config_operator_option | default('')}} --entity-type users --entity-name {{ user_username }} --bootstrap-server {{ bootstrap_server_host }}:{{ bootstrap_server_port }}"
+      register: operation_result
+      changed_when: False

--- a/roles/amq_streams_broker/tasks/user-scram/create.yml
+++ b/roles/amq_streams_broker/tasks/user-scram/create.yml
@@ -1,0 +1,25 @@
+---
+- name: "Create user using the bootstrap server."
+  block:
+    - name: "Set password to create user."
+      ansible.builtin.set_fact:
+        bootstrap_create_operator_password_option: "--add-config 'SCRAM-SHA-512=[password={{ user_password }}]'"
+      when:
+        - user_password is defined
+
+    - name: "Use bootstrap server to create user {{ user_username }}"
+      ansible.builtin.include_tasks: user-scram/bootstrap.yml
+      vars:
+        bootstrap_operator: "--alter"
+        bootstrap_operator_options: "{{ bootstrap_create_operator_password_option | default('') }}"
+  rescue:
+    - name: "Set expected error message"
+      ansible.builtin.set_fact:
+        user_already_exists_err_msg: "User '{{ user_username }}' already exists"
+
+    - name: "Ensure errors is only due to user already existing."
+      ansible.builtin.assert:
+        that:
+          - operation_result is defined and operation_result.stdout is defined
+          - user_already_exists_err_msg in operation_result.stdout
+        fail_msg: "{{ operation_result.stdout }}"

--- a/roles/amq_streams_broker/tasks/user-scram/delete.yml
+++ b/roles/amq_streams_broker/tasks/user-scram/delete.yml
@@ -1,0 +1,25 @@
+---
+- name: "Delete user using the bootstrap server."
+  block:
+    - name: "Set password config to delete user."
+      ansible.builtin.set_fact:
+        bootstrap_delete_operator_password_option: "--delete-config SCRAM-SHA-512"
+      when:
+        - user_username is defined
+
+    - name: "Use bootstrap server to delete user {{ user_username }}"
+      ansible.builtin.include_tasks: user-scram/bootstrap.yml
+      vars:
+        bootstrap_operator: "--alter"
+        bootstrap_operator_options: "{{ bootstrap_delete_operator_password_option | default('') }}"
+  rescue:
+    - name: "Set expected error message"
+      ansible.builtin.set_fact:
+        user_not_exists_err_msg: "Attempt to delete a user credential that does not exist"
+
+    - name: "Ensure errors is only due to user does not exist."
+      ansible.builtin.assert:
+        that:
+          - operation_result is defined and operation_result.stdout is defined
+          - user_not_exists_err_msg in operation_result.stdout
+        fail_msg: "{{ operation_result.stdout }}"

--- a/roles/amq_streams_broker/tasks/user-scram/describe.yml
+++ b/roles/amq_streams_broker/tasks/user-scram/describe.yml
@@ -1,0 +1,17 @@
+---
+- name: "Get description of user using the bootstrap server."
+  ansible.builtin.include_tasks: user-scram/bootstrap.yml
+  vars:
+    bootstrap_operator: "--describe"
+
+- name: "Verify that information on {{ user_username }} could be retrieved without any errors."
+  ansible.builtin.assert:
+    that:
+      - operation_result is defined
+      - operation_result.rc is defined and operation_result.rc == 0
+      - operation_result.stdout is defined
+    quiet: True
+
+- name: "Display information on user: {{ user_username }}."
+  ansible.builtin.debug:
+    var: operation_result.stdout

--- a/roles/amq_streams_broker/vars/main.yml
+++ b/roles/amq_streams_broker/vars/main.yml
@@ -22,6 +22,7 @@ amq_streams_broker:
     zookeeper_connection_timeout_ms: "{{ amq_streams_broker_zookeeper_connection_timeout_ms }}"
     group_initial_rebalance_delay_ms: "{{ amq_streams_broker_group_initial_rebalance_delay_ms }}"
     properties_template: "{{ amq_streams_broker_properties_template }}"
+    script: "{{ amq_streams_broker_kafka_config_script }}"
   bootstrap_server:
     host: "{{ amq_streams_broker_bootstrap_server_host }}"
     port: "{{ amq_streams_broker_bootstrap_server_port }}"


### PR DESCRIPTION
This PR completes the #10 with the tasks to operate (create, describe, and delete) SCRAM users in a Kafka cluster with authentication enabled.

Update the Authentication test case