### PR TITLE
✅ Add test for SSL listeners with SASL authentication

### DIFF
--- a/molecule/ssl_auth_sasl/converge.yml
+++ b/molecule/ssl_auth_sasl/converge.yml
@@ -1,0 +1,4 @@
+---
+- import_playbook: ../../playbooks/amq_streams_ssl_auth_sasl.yml
+  vars:
+    amq_streams_common_download_dir: /tmp/

--- a/molecule/ssl_auth_sasl/generate_keys_and_certs.sh
+++ b/molecule/ssl_auth_sasl/generate_keys_and_certs.sh
@@ -1,0 +1,48 @@
+#!/bin/bash -e
+readonly KEYS_HOME='/opt'
+readonly KEYSTORE_FILE="${KEYS_HOME}/server.keystore.jks"
+readonly KAFKA_SERVER_KEY="${KEYS_HOME}/kafka.server.key"
+readonly KAFKA_SERVER_CSR="${KEYS_HOME}/kafka.server.csr"
+readonly KAFKA_SERVER_CRT="${KEYS_HOME}/kafka.server.crt"
+readonly KAFKA_SERVER_P12="${KEYS_HOME}/kafka.server.p12"
+readonly KAFKA_SERVER_TRUSTSTORE="${KEYS_HOME}/server.truststore.jks"
+readonly CLIENT_P12="${KEYS_HOME}/client.p12"
+readonly CLIENT_TRUSTSTORE_JKS="${KEYS_HOME}/client.truststore.jks"
+
+cd "${KEYS_HOME}"
+
+if [ ! -e "${KEYSTORE_FILE}" ]; then
+  keytool -genkey -keystore "${KEYSTORE_FILE}" -alias server -validity 999 -keyalg RSA -keypass password -storepass password -dname "cn=Unknown, ou=Unknown, o=Unknown, c=Unknown"
+fi
+
+if [ ! -e "${KAFKA_SERVER_KEY}" ]; then
+  openssl genrsa -out "${KAFKA_SERVER_KEY}" 2048
+fi
+
+if [ ! -e "${KAFKA_SERVER_CSR}" ]; then
+  openssl req -new -key kafka.server.key -out "${KAFKA_SERVER_CSR}" -passin pass:client11 -subj "/C=US/ST=Molecule/L=Berlin /O=Ansible Middleware/OU=Test/CN=localhost/emailAddress=dummy@localhost.localdomain"
+fi
+
+if [ ! -e "${KAFKA_SERVER_CRT}" ]; then
+  openssl x509 -req -days 999 -in "${KAFKA_SERVER_CSR}" -signkey "${KAFKA_SERVER_KEY}" -out "${KAFKA_SERVER_CRT}" > /dev/null
+fi
+
+if [ ! -e "${KAFKA_SERVER_P12}"  ]; then
+  openssl pkcs12 -export -name localhost -in "${KAFKA_SERVER_CRT}" -inkey "${KAFKA_SERVER_KEY}" -out "${KAFKA_SERVER_P12}" -passout pass:client11
+  keytool -keystore "${KEYSTORE_FILE}" -alias localhost -importkeystore -srckeystore "${KAFKA_SERVER_P12}" -srcstoretype PKCS12 -storepass password -srcstorepass client11 -noprompt
+fi
+
+#* Create truststore importing the certificate
+#
+#```shell
+if [ ! -e "${KAFKA_SERVER_TRUSTSTORE}" ]; then
+  keytool -keystore "${KAFKA_SERVER_TRUSTSTORE}" -alias CARoot -import -file "${KAFKA_SERVER_CRT}" -storepass password -noprompt
+fi
+
+if [ ! -e "${CLIENT_P12}" ]; then
+  openssl pkcs12 -export -in "${KAFKA_SERVER_CRT}" -inkey "${KAFKA_SERVER_KEY}" -out "${CLIENT_P12}" -passout pass:client11
+fi
+
+if [ ! -e "${CLIENT_TRUSTSTORE_JKS}" ]; then
+  keytool -keystore "${CLIENT_TRUSTSTORE_JKS}" -alias CARoot -import -file "${KAFKA_SERVER_CRT}" -storepass password -keypass password -noprompt
+fi

--- a/molecule/ssl_auth_sasl/molecule.yml
+++ b/molecule/ssl_auth_sasl/molecule.yml
@@ -1,0 +1,45 @@
+---
+driver:
+  name: docker
+platforms:
+  - name: instance
+    image: registry.access.redhat.com/ubi8/ubi-init:latest
+    command: "/usr/sbin/init"
+    pre_build_image: true
+    privileged: true
+    groups:
+     - zookeepers
+     - brokers
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      interpreter_python: auto_silent
+    ssh_connection:
+      pipelining: false
+  playbooks:
+    prepare: prepare.yml
+    converge: converge.yml
+    verify: verify.yml
+  inventory:
+    host_vars:
+      localhost:
+        ansible_python_interpreter: "{{ ansible_playbook_python }}"
+  env:
+    ANSIBLE_FORCE_COLOR: "true"
+verifier:
+  name: ansible
+scenario:
+  test_sequence:
+    - dependency
+    - cleanup
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - side_effect
+    - verify
+    - cleanup
+    - destroy

--- a/molecule/ssl_auth_sasl/prepare.yml
+++ b/molecule/ssl_auth_sasl/prepare.yml
@@ -1,0 +1,42 @@
+---
+- name: Prepare
+  hosts: all
+#  collections:
+#    - community.general.java_keystore
+#    - community.crypto
+  tasks:
+
+    - name: "Ensure required packages are installed."
+      ansible.builtin.yum:
+        name:
+          - sudo
+          - java-17-openjdk-headless
+          - openssl
+        state: present
+
+    - ansible.builtin.copy:
+        src: generate_keys_and_certs.sh
+        dest: /tmp/
+        owner: root
+        group: root
+        mode: 0077
+
+    - name: "Generate required SSL artifacts."
+      ansible.builtin.command: "/tmp/generate_keys_and_certs.sh"
+      register: output
+
+    - ansible.builtin.debug:
+        var: output
+
+# TODO: use Ansible crypto and jks collections to replace above script
+#    - name: Generate an OpenSSH keypair with the default values (4096 bits, rsa)
+#      community.crypto.openssh_keypair:
+#        path: /tmp/id_ssh_rsa
+#
+#    - name: Create a keystore for the given certificate/private key pair (inline)
+#      community.general.java_keystore:
+#        name: example
+#        certificate: /etc/ssl/certs/ca-bundle.crt
+#        private_key: /tmp/id_ssh_rsa
+#        password: changeit
+#        dest: /etc/security/keystore.jks

--- a/molecule/ssl_auth_sasl/requirements.yml
+++ b/molecule/ssl_auth_sasl/requirements.yml
@@ -1,0 +1,6 @@
+---
+collections:
+  - name: community.general
+  - name: ansible.posix
+  - name: community.docker
+    version: ">=1.9.1"

--- a/molecule/ssl_auth_sasl/verify.yml
+++ b/molecule/ssl_auth_sasl/verify.yml
@@ -1,0 +1,14 @@
+---
+- name: Verify
+  hosts: all
+  tasks:
+    - name: Populate service facts
+      ansible.builtin.service_facts:
+
+    - name: Check if amq_streams service started
+      assert:
+        that:
+          - ansible_facts.services["amq_streams_broker.service"]["state"] == "running"
+          - ansible_facts.services["amq_streams_broker.service"]["status"] == "enabled"
+          - ansible_facts.services["amq_streams_zookeeper.service"]["state"] == "running"
+          - ansible_facts.services["amq_streams_zookeeper.service"]["status"] == "enabled"


### PR DESCRIPTION
Add molecule test to verify the use case of a kafka cluster using SSL listeners and SASL (PLAIN, SCRAM) authentication.