### PR TITLE
:closed_lock_with_key: Enable secured connection from Kafka Connect

### DIFF
--- a/playbooks/amq_streams_ssl_auth_sasl.yml
+++ b/playbooks/amq_streams_ssl_auth_sasl.yml
@@ -66,6 +66,20 @@
       - name: otherTopic
         partitions: 1
         replication_factor: 1
+
+    # Enabling SSL/TLS communications between Kafka Connect and Kafka Broker
+    amq_streams_connect_broker_tls_enabled: true
+    amq_streams_connect_broker_tls_truststore_client_password: password
+
+    # Enabled Broker Authentication
+    amq_streams_connect_broker_auth_enabled: 'true'
+    amq_streams_connect_broker_auth_scram_enabled: 'false'
+    amq_streams_connect_broker_auth_username: admin
+    amq_streams_connect_broker_auth_password: p@ssw0rd
+
+    # Connection to SSL endpoint
+    amq_streams_connect_bootstrap_servers: localhost:9093
+
   roles:
     - role: amq_streams_zookeeper
   tasks:
@@ -144,6 +158,15 @@
       vars:
         user_username: "{{ user.username }}"
 
+    - name: "Ensure AMQ Streams Connect is running and available."
+      ansible.builtin.include_role:
+        name: amq_streams_connect
+      vars:
+        amq_streams_common_skip_download: true
+        connectors:
+          - { name: "file", path: "connectors/file.yml" }
+          - { name: "dummy", path: "dummy.yml" }
+
   post_tasks:
     - name: "Display numbers of Zookeeper instances managed by Ansible."
       ansible.builtin.debug:
@@ -165,4 +188,9 @@
     - name: "Validate that Broker deployment is functional."
       ansible.builtin.include_role:
         name: amq_streams_broker
+        tasks_from: validate.yml
+
+    - name: "Validate that Connect deployment is functional."
+      ansible.builtin.include_role:
+        name: amq_streams_connect
         tasks_from: validate.yml

--- a/playbooks/amq_streams_ssl_no_auth.yml
+++ b/playbooks/amq_streams_ssl_no_auth.yml
@@ -36,6 +36,13 @@
       - name: otherTopic
         partitions: 1
         replication_factor: 1
+
+    # Enabling SSL/TLS communications between Kafka Connect and Kafka Broker
+    amq_streams_connect_broker_tls_enabled: true
+    amq_streams_connect_broker_tls_truststore_client_password: password
+
+    # Connection to SSL endpoint
+    amq_streams_connect_bootstrap_servers: localhost:9093
   roles:
     - role: amq_streams_zookeeper
   tasks:
@@ -114,6 +121,15 @@
       vars:
         user_username: "{{ user.username }}"
 
+    - name: "Ensure AMQ Streams Connect is running and available."
+      ansible.builtin.include_role:
+        name: amq_streams_connect
+      vars:
+        amq_streams_common_skip_download: true
+        connectors:
+          - { name: "file", path: "connectors/file.yml" }
+          - { name: "dummy", path: "dummy.yml" }
+
   post_tasks:
     - name: "Display numbers of Zookeeper instances managed by Ansible."
       ansible.builtin.debug:
@@ -135,4 +151,9 @@
     - name: "Validate that Broker deployment is functional."
       ansible.builtin.include_role:
         name: amq_streams_broker
+        tasks_from: validate.yml
+
+    - name: "Validate that Connect deployment is functional."
+      ansible.builtin.include_role:
+        name: amq_streams_connect
         tasks_from: validate.yml

--- a/roles/amq_streams_broker/templates/admin-cli.properties.j2
+++ b/roles/amq_streams_broker/templates/admin-cli.properties.j2
@@ -1,7 +1,6 @@
-// {{ ansible_managed }}
+# {{ ansible_managed }}
 
-// Security protocol
-
+# Security protocol
 {% if amq_streams_broker_tls_enabled and not amq_streams_broker_auth_enabled %}
 security.protocol=SSL
 {% elif amq_streams_broker_tls_enabled and amq_streams_broker_auth_enabled %}
@@ -25,6 +24,7 @@ sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule require
 {% endif %}
 
 {% if amq_streams_broker_tls_enabled %}
+# SSL truststore
 ssl.truststore.location={{ amq_streams_broker_tls_truststore_client_location }}/{{ amq_streams_broker_tls_truststore_client }}
 ssl.truststore.password={{ amq_streams_broker_tls_truststore_client_password }}
 # Disable hostname verification

--- a/roles/amq_streams_broker/templates/server.properties.j2
+++ b/roles/amq_streams_broker/templates/server.properties.j2
@@ -78,6 +78,8 @@ ssl.truststore.location={{ amq_streams_broker_tls_truststore_location }}/{{ amq_
 ssl.truststore.password={{ amq_streams_broker_tls_truststore_password }}
 {% if amq_streams_broker_auth_enabled %}
 ssl.client.auth=required
+{% else %}
+ssl.client.auth=none
 {% endif %}
 {% endif %}
 

--- a/roles/amq_streams_connect/README.md
+++ b/roles/amq_streams_connect/README.md
@@ -33,6 +33,24 @@ The following are a set of required variables for the role:
 | Variable | Description | Required |
 |:---------|:------------|:---------|
 
+If the Kafka Connect cluster has to connect to a Kafka Broker with authentication enabled, then
+the `amq_streams_connect_broker_auth_enabled` is required, and the following variables to execute
+the role successfully:
+
+| Variable | Description | Required | Sample |
+|:---------|:------------|:---------|:-------|
+|`amq_streams_connect_bootstrap_servers` | Bootstrap connection to the Kafka Brokers | `true` |
+`localhost:9092` |
+|`amq_streams_connect_broker_admin_mechanism` | Authentication mechanism to connect to the Kafka brokers | `true` | `PLAIN` |
+|`amq_streams_connect_broker_auth_username` | Default user to connect to the Kafka brokers | `true` | `broker` |
+|`amq_streams_connect_broker_auth_password` | Default password to connecto to the Kafka brokers | `true` | `PLEASE_CHANGEME_IAMNOTGOOD_FOR_PRODUCTION` |
+|`amq_streams_broker_admin_password` | Default password of the admin user to manage topics | `false` |  |
+|`amq_streams_connect_broker_tls_enabled` | Enable SSL connections to the Kafka brokers | `false` | `false` |
+|`amq_streams_connect_broker_tls_truststore_client_dir` | Local folder of the client truststore to use | `true` | `/tmp` |
+|`amq_streams_connect_broker_tls_truststore_client` | Filename of the truststore | `true` | `client.truststore.jks` |
+|`amq_streams_connect_broker_tls_truststore_client_location` | Location of the truststore in the Kafka Connect host | `true` | `/opt` |
+|`amq_streams_connect_broker_tls_truststore_client_password` | Password of the truststore | `true` | `PLEASE_CHANGEME_IAMNOTGOOD_FOR_PRODUCTION` |
+
 ## License
 
 Apache License v2.0 or later
@@ -42,4 +60,3 @@ Apache License v2.0 or later
 * [Romain Pelisse](https://github.com/rpelisse)
 * [Guido Grazioli](https://github.com/guidograzioli)
 * [Roman Martin](https://github.com/rmarting)
-

--- a/roles/amq_streams_connect/defaults/main.yml
+++ b/roles/amq_streams_connect/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 amq_streams_connect_user: amq_streams_connect
 amq_streams_connect_group: amq_streams
-amq_streams_connect_standalone_conf: "{{ amq_streams_common_home }}/config/connect-standalone.properties"
+amq_streams_connect_standalone_conf: "/etc/amq_streams_connect-standalone.properties"
 amq_streams_connect_file_connector_data:
   - foo
   - bar
@@ -24,6 +24,7 @@ amq_streams_connect_bootstrap_servers: localhost:9092
 # Enabling Broker Authentication
 amq_streams_connect_broker_auth_enabled: false
 amq_streams_connect_broker_auth_scram_enabled: false
+amq_streams_connect_broker_admin_mechanism: PLAIN
 amq_streams_connect_broker_auth_username: broker
 amq_streams_connect_broker_auth_password: PLEASE_CHANGEME_IAMNOTGOOD_FOR_PRODUCTION
 amq_streams_connect_zookeeper_session_timeout_ms: 18000
@@ -32,3 +33,10 @@ amq_streams_connect_server_log_validation_min_size: 20
 amq_streams_connect_config_template: templates/connect-standalone.properties.j2
 amq_streams_connect_service_config_template: templates/service.conf.j2
 amq_streams_connect_server_port: 8083
+
+# SSL/TLS Connections
+amq_streams_connect_broker_tls_enabled: false
+amq_streams_connect_broker_tls_truststore_client_dir: /tmp
+amq_streams_connect_broker_tls_truststore_client: client.truststore.jks
+amq_streams_connect_broker_tls_truststore_client_location: /opt
+amq_streams_connect_broker_tls_truststore_client_password: PLEASE_CHANGEME_IAMNOTGOOD_FOR_PRODUCTION

--- a/roles/amq_streams_connect/templates/connect-standalone.properties.j2
+++ b/roles/amq_streams_connect/templates/connect-standalone.properties.j2
@@ -18,19 +18,62 @@
 # These are defaults. This file just demonstrates how to override some settings.
 bootstrap.servers={{ amq_streams_connect_bootstrap_servers }}
 
-{% if amq_streams_connect_broker_auth_enabled is defined and amq_streams_connect_broker_auth_enabled %}
+# Security protocol
+{% if amq_streams_connect_broker_tls_enabled and not amq_streams_connect_broker_auth_enabled %}
+security.protocol=SSL
+producer.security.protocol=SSL
+consumer.security.protocol=SSL
+{% elif amq_streams_connect_broker_tls_enabled and amq_streams_connect_broker_auth_enabled %}
+security.protocol=SASL_SSL
+producer.security.protocol=SASL_SSL
+consumer.security.protocol=SASL_SSL
+{% elif not amq_streams_connect_broker_tls_enabled and amq_streams_connect_broker_auth_enabled %}
 security.protocol=SASL_PLAINTEXT
-{% if amq_streams_connect_broker_auth_scram_enabled is defined %}
-sasl.mechanism=SCRAM-SHA-512
-sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required \
-                 username={{ amq_streams_connect_broker_auth_username }} \
-                 password={{ amq_streams_connect_broker_auth_password }};
+producer.security.protocol=SASL_PLAINTEXT
+consumer.security.protocol=SASL_PLAINTEXT
 {% else %}
-sasl.mechanism=PLAIN
-sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required \
-                 username={{ amq_streams_connect_broker_auth_username }} \
-                 password={{ amq_streams_connect_broker_auth_password }};
+# No security protocol
 {% endif %}
+
+{% if amq_streams_connect_broker_auth_enabled is defined and amq_streams_connect_broker_auth_enabled %}
+{% if amq_streams_connect_broker_admin_mechanism == "PLAIN" %}
+# Plain Login Module
+sasl.mechanism=PLAIN
+sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="{{ amq_streams_connect_broker_auth_username }}" password="{{ amq_streams_connect_broker_auth_password }}";
+# Producer
+producer.sasl.mechanism=PLAIN
+producer.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="{{ amq_streams_connect_broker_auth_username }}" password="{{ amq_streams_connect_broker_auth_password }}";
+# Consumer
+consumer.sasl.mechanism=PLAIN
+consumer.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="{{ amq_streams_connect_broker_auth_username }}" password="{{ amq_streams_connect_broker_auth_password }}";
+{% elif amq_streams_connect_broker_admin_mechanism == "SCRAM-SHA-512" %}
+# SCRAM Login Module
+sasl.mechanism=SCRAM-SHA-512
+sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="{{ amq_streams_connect_broker_auth_username }}" password="{{ amq_streams_connect_broker_auth_password }}";
+# Producer
+producer.sasl.mechanism=SCRAM-SHA-512
+producer.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="{{ amq_streams_connect_broker_auth_username }}" password="{{ amq_streams_connect_broker_auth_password }}";
+# Consumer
+consumer.sasl.mechanism=SCRAM-SHA-512
+consumer.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="{{ amq_streams_connect_broker_auth_username }}" password="{{ amq_streams_connect_broker_auth_password }}";
+{% endif %}
+{% endif %}
+
+{% if amq_streams_connect_broker_tls_enabled %}
+ssl.truststore.location={{ amq_streams_connect_broker_tls_truststore_client_location }}/{{ amq_streams_connect_broker_tls_truststore_client }}
+ssl.truststore.password={{ amq_streams_connect_broker_tls_truststore_client_password }}
+# Disable hostname verification
+ssl.endpoint.identification.algorithm=
+# Producer
+producer.ssl.truststore.location={{ amq_streams_connect_broker_tls_truststore_client_location }}/{{ amq_streams_connect_broker_tls_truststore_client }}
+producer.ssl.truststore.password={{ amq_streams_connect_broker_tls_truststore_client_password }}
+# Disable hostname verification
+producer.ssl.endpoint.identification.algorithm=
+# Consumer
+consumer.ssl.truststore.location={{ amq_streams_connect_broker_tls_truststore_client_location }}/{{ amq_streams_connect_broker_tls_truststore_client }}
+consumer.ssl.truststore.password={{ amq_streams_connect_broker_tls_truststore_client_password }}
+# Disable hostname verification
+consumer.ssl.endpoint.identification.algorithm=
 {% endif %}
 
 # The converters specify the format of data in Kafka and how to translate it into Connect data. Every Connect user will


### PR DESCRIPTION
This PR extends #63 alllowing secured connections from kafka connect to Kafka broker under the following authentication use cases.

- SSL without authentication
- SSL with authentication (PLAIN, SCRAM)
