### PR TITLE
molecule does not wait sanity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,20 +14,14 @@ env:
   PYTEST_ADDOPTS: '--color=yes'
 
 jobs:
-  ci:
+  sanity:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_version: ["3.11"]
-        molecule_test:
-          - default
-          - all_auth
-          - connect
-          - ssl_auth_sasl
-          - ssl_no_auth
+        python_version: ["3.9", "3.11"]
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: ansible_collections/middleware_automation/amq_streams
 
@@ -42,13 +36,12 @@ jobs:
           mkdir -p /home/runner/.ansible/
           ln -s /home/runner/work/amq_streams/amq_streams /home/runner/.ansible/collections
 
-      - name: Install yamllint, ansible and molecule
+      - name: Install yamllint, ansible
         run: |
           python -m pip install --upgrade pip
-          pip install yamllint 'molecule>=4.0.4' 'molecule-plugins[docker]>=23.0.0' ansible-core flake8 ansible-lint voluptuous
+          pip install yamllint ansible-core flake8 ansible-lint voluptuous
           pip install -r ansible_collections/middleware_automation/amq_streams/requirements.txt
           ansible-galaxy collection install -r ansible_collections/middleware_automation/amq_streams/requirements.yml -p /home/runner/.ansible/collections --force-with-deps
-          ansible-galaxy collection install -r ansible_collections/middleware_automation/amq_streams/molecule/default/requirements.yml -p /home/runner/.ansible/collections
 
       - name: Install ansible-lint custom rules
         uses: actions/checkout@v2
@@ -65,6 +58,43 @@ jobs:
       - name: Run sanity tests
         run: ansible-test sanity -v --color --python ${{ matrix.python_version }} --exclude changelogs/fragments/.gitignore --skip-test symlinks --skip-test shebang
         working-directory: ./ansible_collections/middleware_automation/amq_streams
+
+  molecule:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python_version: ["3.11"]
+        ansible_version: ["2.15"]
+        molecule_test:
+          - default
+          - all_auth
+          - connect
+          - ssl_auth_sasl
+          - ssl_no_auth
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          path: ansible_collections/middleware_automation/amq_streams
+
+      - name: Set up Python ${{ matrix.python_version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python_version }}
+          cache: 'pip'
+
+      - name: Create default collection path
+        run: |
+          mkdir -p /home/runner/.ansible/
+          ln -s /home/runner/work/amq_streams/amq_streams /home/runner/.ansible/collections
+
+      - name: Install ansible and molecule
+        run: |
+          python -m pip install --upgrade pip
+          pip install 'molecule>=4.0.4' 'molecule-plugins[docker]>=23.0.0' ansible-core==${{ matrix.ansible_version }}
+          pip install -r ansible_collections/middleware_automation/amq_streams/requirements.txt
+          ansible-galaxy collection install -r ansible_collections/middleware_automation/amq_streams/requirements.yml -p /home/runner/.ansible/collections --force-with-deps
+          ansible-galaxy collection install -r ansible_collections/middleware_automation/amq_streams/molecule/default/requirements.yml -p /home/runner/.ansible/collections
 
       - name: Run molecule test
         run: molecule test -s ${{ matrix.molecule_test }}


### PR DESCRIPTION
while adding more tests (sanity runs python 3.9 and 3.11, molecule potentially can run other ansible-core than 2.15) this change should also reduce by another minute or two from the build time