### PR TITLE
Add a wait stmt to allow user to wait for Zookeeper to be active, before starting broker

### DIFF
--- a/roles/amq_streams_broker/defaults/main.yml
+++ b/roles/amq_streams_broker/defaults/main.yml
@@ -47,9 +47,9 @@ amq_streams_broker_instance_count: "{{ groups[amq_streams_broker_inventory_group
 
 amq_streams_deployment_balance_check_enabled: true
 
-amq_streams_broker_zookeeper_host_default_value: localhost
+amq_streams_broker_zookeeper_host_default_value: "{{ groups['zookeepers'][0] | default('localhost') }}"
 amq_streams_broker_zookeeper_port_default_value: 2181
-amq_streams_broker_zookeeper_wait: True
+amq_streams_broker_zookeeper_wait: False
 
 # Broker-Zookeeper Authentication with SASL
 amq_streams_zookeeper_auth_enabled: false

--- a/roles/amq_streams_broker/tasks/main.yml
+++ b/roles/amq_streams_broker/tasks/main.yml
@@ -54,15 +54,14 @@
   when:
     - amq_streams_zookeeper_auth_enabled is defined and amq_streams_zookeeper_auth_enabled
 
-- name: "Wait for Zookeeper to be available - if host and port are provided."
+- name: "Wait for Zookeeper to be available - if enabled ({{ amq_streams_broker_zookeeper_host }}:{{ amq_streams_broker_zookeeper_port }})."
   ansible.builtin.wait_for:
     host: "{{ amq_streams_broker_zookeeper_host }}"
     port: "{{ amq_streams_broker_zookeeper_port }}"
   when:
-    - 0 > 1 # Disabled until find a way to test the Zookeeper cluster connection (including all the zknodes)
+    - amq_streams_broker_zookeeper_wait is defined and amq_streams_broker_zookeeper_wait
     - amq_streams_broker_zookeeper_host is defined
     - amq_streams_broker_zookeeper_port is defined
-    - amq_streams_broker_zookeeper_wait is defined and amq_streams_broker_zookeeper_wait
 
 - name: "Copy Server Keystore with certificates"
   ansible.builtin.copy:


### PR DESCRIPTION
Issue: https://github.com/ansible-middleware/amq_streams/issues/83