### PR TITLE
Add a custom broker.id based in a inventory file

### DIFF
--- a/roles/amq_streams_broker/README.md
+++ b/roles/amq_streams_broker/README.md
@@ -80,6 +80,7 @@ broker4
 |`amq_streams_broker_auth_listeners` | Default list of authenticated listeners | `PLAINTEXT:PLAINTEXT` |
 |`amq_streams_broker_auth_sasl_mechanisms` | Default list of authenticated SASL mechanism | `PLAIN` |
 |`amq_streams_broker_inventory_group` | Identify the group of broker nodes | `groups['brokers']` |
+|`amq_streams_broker_broker_id` | Identify the broker with specific id in the inventory
 |`amq_streams_broker_topics` | List of topics to create. Each topics requires the `name` property, and optionally the `partitions` and `replication_factor`. | |
 
 ## Role Variables

--- a/roles/amq_streams_broker/tasks/main.yml
+++ b/roles/amq_streams_broker/tasks/main.yml
@@ -34,7 +34,7 @@
 
 - name: "Set server_id for {{ amq_streams_broker.service_name }} service."
   ansible.builtin.set_fact:
-    server_id: "{{ broker_id | default('0') }}"
+    server_id: "{{ amq_streams_broker_broker_id | default('0') }}"
   when:
     - not server_id is defined
 

--- a/roles/amq_streams_broker/tasks/service.yml
+++ b/roles/amq_streams_broker/tasks/service.yml
@@ -29,7 +29,7 @@
     server_start: "{{ amq_streams_broker.server_start }}"
     server_config: "{{ amq_streams_broker_config }}"
     server_config_template: "{{ amq_streams_broker.config.template }}"
-    server_id: "{{ broker_id | default('0') }}"
+    server_id: "{{ amq_streams_broker_broker_id | default('0') }}"
     server_user: "{{ amq_streams_broker_user | default(omit) }}"
     server_group: "{{ amq_streams_broker_group | default(omit) }}"
     server_log_dir: "{{ amq_streams_broker_logs_dir | default(omit) }}"

--- a/roles/amq_streams_broker/templates/server.properties.j2
+++ b/roles/amq_streams_broker/templates/server.properties.j2
@@ -23,7 +23,8 @@
 ############################# Server Basics #############################
 
 # The id of the broker. This must be set to a unique integer for each broker.
-broker.id={{ amq_streams_broker_inventory_group.index(inventory_hostname) }}
+broker.id={{ amq_streams_broker_broker_id | default(amq_streams_broker_inventory_group.index(inventory_hostname)) }}
+
 
 ############################# Socket Server Settings #############################
 


### PR DESCRIPTION
- Modifies the broker.id on a template to allow hostvar if it is specified. If it is not defined, it uses the standard indexing from the template.
- Closes https://github.com/ansible-middleware/amq_streams/issues/82