### PR TITLE
Add custom zookeeper_id for each host based in inventory

### DIFF
--- a/roles/amq_streams_zookeeper/README.md
+++ b/roles/amq_streams_zookeeper/README.md
@@ -35,6 +35,7 @@ zknode3
 |`amq_streams_zookeeper_admin_enable_server` | Enable zookeeper administration server | `false` |
 |`amq_streams_zookeeper_instance_count_enabled` | Count zookeeper instances | `true` |
 |`amq_streams_zookeeper_instance_count` |  | `0` |
+|`amq_streams_zookeeper_zookeeper_id` | Zookeeper variable to identify the zookeeper in a cluster | |
 |`amq_streams_zookeeper_java_opts` | Default values to apply to `KAFKA_OPTS` env variable |  |
 |`amq_streams_zookeeper_java_heap_opts` | Default values to apply to `KAFKA_HEAP_OPTS` env variable | `-Xmx512M -Xms512M` |
 |`amq_streams_zookeeper_java_performance_opts` | Default values to apply to `KAFKA_JVM_PERFORMANCE_OPTS` env variable |  |

--- a/roles/amq_streams_zookeeper/tasks/main.yml
+++ b/roles/amq_streams_zookeeper/tasks/main.yml
@@ -25,7 +25,7 @@
 
 - name: "Configure 'myid' file based on the position in the zookeepers group"
   copy:
-    content: "{{ amq_streams_zookeeper_inventory_group.index(inventory_hostname) + 1 }}"
+    content: "{{ amq_streams_zookeeper_zookeeper_id | default(amq_streams_zookeeper_inventory_group.index(inventory_hostname) + 1) }}"
     dest: "{{ amq_streams_zookeeper_data_dir }}/myid"
     owner: "{{ amq_streams_zookeeper_user | default(omit) }}"
     group: "{{ amq_streams_zookeeper_group | default(omit) }}"


### PR DESCRIPTION
- Modifies the zookeeper_id  on a template to allow hostvar if it is defined. If it is not specified, it uses the standard indexing from the template.
- Closes https://github.com/ansible-middleware/amq_streams/issues/81