### PR TITLE
Fix certification requirements for AMQ Streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,13 +87,18 @@ It is possible to perform downloads from alternate sources (like corporate Nexus
 `amq_streams_common_download_url` variable; make sure the final downloaded filename matches with the source filename
 described by the `amq_streams_common_archive_file` variable (ie. *kafka_-a.b.c-x.y.z.tgz*).
 
+
+## Support
+
 <!--start support -->
-For Red Hat customers, this collection is released as a [Technology Preview](https://access.redhat.com/support/offerings/techpreview) feature as the [Red Hat Ansible certified content collection for AMQ Streams](https://console.redhat.com/ansible/automation-hub/repo/published/redhat/amq_streams). If you have any issues or questions related to this collection, please contact <Ansible-middleware-core@redhat.com> or open an issue at https://github.com/ansible-middleware/amq_streams/issues.
+
+For Red Hat customers, this collection is released as a [Technology Preview](https://access.redhat.com/support/offerings/techpreview) feature as the [Red Hat Ansible certified content collection for AMQ Streams](https://console.redhat.com/ansible/automation-hub/repo/published/redhat/amq_streams). If you have any issues or questions related to this collection, please contact <Ansible-middleware-core@redhat.com> or open an [issue](https://github.com/ansible-middleware/amq_streams/issues).
+
 <!--end support -->
 
 ## Release and Upgrade Notes
 
-For details on changes between versions, please see [the changelog for this collection](https://github.com/ansible-middleware/amq_streams/blob/main/CHANGELOG.rst).
+For details on changes between versions, please see the [CHANGELOG](https://github.com/ansible-middleware/amq_streams/blob/main/CHANGELOG.rst) for this collection.
 
 ## License
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 antsibull>=0.17.0
 antsibull-docs
 antsibull-changelog
-ansible-base>=2.10.12
+ansible-core>=2.16.0
 sphinx-rtd-theme
 git+https://github.com/felixfontein/ansible-basic-sphinx-ext
 myst-parser

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -31,6 +31,7 @@ build_ignore:
   - .github
   - .ansible-lint
   - .yamllint
+  - .DS_Store
   - '*.tar.gz'
   - '*.zip'
   - molecule


### PR DESCRIPTION
- Add .DS_Store to build_ignore in galaxy.yml
- Convert bare URL to markdown link in README support section

[AMW-522](https://redhat.atlassian.net/browse/AMW-522)