### PR TITLE
Fix AMQ Streams downstream compatibility issues

### DIFF
--- a/roles/amq_streams_common/defaults/main.yml
+++ b/roles/amq_streams_common/defaults/main.yml
@@ -1,7 +1,8 @@
 ---
 amq_streams_common_product_version: 4.1.1
 amq_streams_common_rhn_product_version: 2.6.0
-amq_streams_common_rhn_home_dir: "kafka_2.13-{{ amq_streams_common_product_version }}.redhat-00005"
+amq_streams_common_rhn_kafka_version: 3.6.0
+amq_streams_common_rhn_home_dir: "kafka_{{ amq_streams_common_scala_version }}-{{ amq_streams_common_rhn_kafka_version }}.redhat-00005"
 amq_streams_common_rhn_product_path: /opt
 amq_streams_common_redhat_enabled: false
 amq_streams_common_rhn_product_category: 'jboss.amq.streams'
@@ -29,7 +30,7 @@ amq_streams_common_openjdk_version: 17
 
 amq_streams_common_systemd_home: '/usr/lib/systemd/system'
 amq_streams_common_systemd_service_config_file_template: 'templates/service_systemd.j2'
-amq_streams_common_home: "{{ amq_streams_common_install_dir }}/kafka_{{ amq_streams_common_version }}/"
+amq_streams_common_home: "{{ amq_streams_common_install_dir }}/kafka_{{ amq_streams_common_version }}"
 
 amq_streams_common_firewalld_package_name:
   - firewalld

--- a/roles/amq_streams_common/tasks/rhn/download.yml
+++ b/roles/amq_streams_common/tasks/rhn/download.yml
@@ -4,7 +4,7 @@
     that:
       - rhn_username is defined and rhn_username | length > 0
       - rhn_password is defined and rhn_password | length > 0
-      - rhn_product_id is defined and rhn_product_id | length > 0
+      - rhn_product_id is defined
       - rhn_product_path is defined and rhn_product_path | length > 0
     quiet: true
 

--- a/roles/amq_streams_kraft/defaults/main.yml
+++ b/roles/amq_streams_kraft/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 amq_streams_install_dir: "/opt"
-amq_streams_kafka_home: "{{ amq_streams_install_dir }}/kafka_{{ amq_streams_common_version }}/"
+amq_streams_kafka_home: "{{ amq_streams_common_home }}"
 amq_streams_kraft_config_dir: "{{ amq_streams_kafka_home }}/config"
 amq_streams_kraft_data_dir: "{{ amq_streams_kafka_home }}/data/kraft"
 amq_streams_cluster_id: ""


### PR DESCRIPTION
Fixed multiple issues preventing downstream tests from passing:

1. rhn_product_id validation - removed length check on integer type
2. kafka_home path construction - use amq_streams_common_home instead of rebuilding path
3. Kafka version mismatch - AMQ Streams 2.6.0 bundles Kafka 3.6.0, not 4.1.1
   - Added amq_streams_common_rhn_kafka_version: 3.6.0
   - Updated rhn_home_dir to use scala_version variable and rhn_kafka_version

All downstream molecule tests now passing.

[AMW-566](https://redhat.atlassian.net/browse/AMW-566)