### PR TITLE
Remove requirements.txt and related documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,6 @@ The amq_streams collection also depends on the following python packages to be p
 
 * _none at the moment_
 
-A requirement file is provided to install:
-
-    pip install -r requirements.txt
 <!--end galaxy_download -->
 ### Build and install locally
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -42,13 +42,7 @@ cd amq_streams
 ansible-galaxy collection install -r requirements.yml
 ```
 
-4. Install collection python deps
-
-```shell
-pip install -r requirements.txt
-```
-
-5. Create inventory for localhost
+4. Create inventory for localhost
 
 ```shell
 cat << EOF > inventory2

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,6 +9,7 @@ authors:
   - Roman Martin <rmarting@redhat.com>
   - Guilherme Baufaker Rêgo <baufaker@redhat.com>
 description: Install and configure Red Hat AMQ Streams (kafka) deployments
+license: ["Apache-2.0"]
 license_file: "LICENSE"
 tags:
   - java

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-#################################################
-# Python dependencies for the controller / CI.
-# Install with: pip install -r requirements.txt
-#
-# ansible-lint 24.x is incompatible with ansible-core 2.19+ (removed
-# ansible.parsing.yaml.constructor). Use 25.8.1+ with current Ansible 11 / core 2.20.
-ansible-lint>=25.8.1


### PR DESCRIPTION
Collection has no runtime Python dependencies, following the pattern of wildfly, quarkus, and jbcs collections. ansible-lint is a development tool installed by CI, not a runtime requirement.

- Delete requirements.txt (only contained ansible-lint)
- Remove pip install section from README.md
- Remove pip install step from docs/testing.md

[AMW-569](https://redhat.atlassian.net/browse/AMW-569)