### PR TITLE
Replace deprecated top-level fact variables with ansible_fact

### DIFF
--- a/molecule/prepare.yml
+++ b/molecule/prepare.yml
@@ -13,7 +13,7 @@
       ansible.builtin.yum:
         name: "{{ sudo_pkg_name }}"
       when:
-        - ansible_user_id == 'root'
+        - ansible_facts['user_id'] == 'root'
 
     - name: Gather the package facts
       ansible.builtin.package_facts:

--- a/roles/amq_streams_broker/tasks/main.yml
+++ b/roles/amq_streams_broker/tasks/main.yml
@@ -33,7 +33,7 @@
     ulimit_user: "{{ amq_streams_broker_user }}"
     ulimit_limit: "{{ amq_streams_broker_ulimit_max_value }}"
   when:
-    - ansible_distribution == "RedHat"
+    - ansible_facts['distribution'] == "RedHat"
 
 - name: "Escalate privilege to root"
   become: "{{ amq_streams_broker_config_files_requires_privilege_escalation }}"

--- a/roles/amq_streams_connect/tasks/main.yml
+++ b/roles/amq_streams_connect/tasks/main.yml
@@ -22,7 +22,7 @@
     ulimit_user: "{{ amq_streams_connect_user }}"
     ulimit_limit: "{{ amq_streams_connect_ulimit_max_value }}"
   when:
-    - ansible_distribution == "RedHat"
+    - ansible_facts['distribution'] == "RedHat"
 
 - name: "Ensure connectors for AMQ Connect are deployed."
   ansible.builtin.include_tasks: "{{ connector.path }}"

--- a/roles/amq_streams_zookeeper/tasks/main.yml
+++ b/roles/amq_streams_zookeeper/tasks/main.yml
@@ -23,7 +23,7 @@
     ulimit_user: "{{ amq_streams_zookeeper_user }}"
     ulimit_limit: "{{ amq_streams_zookeeper_ulimit_max_value }}"
   when:
-    - ansible_distribution == "RedHat"
+    - ansible_facts['distribution'] == "RedHat"
     - amq_streams_common_systctl_update_enable is defined
     - amq_streams_common_systctl_update_enable | bool
 


### PR DESCRIPTION
Fix deprecation warnings:

[DEPRECATION WARNING]: INJECT_FACTS_AS_VARS default to True is deprecated, top-level facts will not be auto injected after the change. This feature will be removed from ansible-core version 2.24.

[AMW-631](https://redhat.atlassian.net/browse/AMW-631)